### PR TITLE
Using displayLarge instead of headline1

### DIFF
--- a/lib/simple_timer.dart
+++ b/lib/simple_timer.dart
@@ -219,7 +219,7 @@ class TimerState extends State<SimpleTimer> with SingleTickerProviderStateMixin 
   }
 
   TextStyle getProgressTextStyle() {
-    return TextStyle(fontSize: Theme.of(context).textTheme.headline1!.fontSize).merge(widget.progressTextStyle);
+    return TextStyle(fontSize: Theme.of(context).textTheme.displayLarge!.fontSize).merge(widget.progressTextStyle);
   }
 
   @override


### PR DESCRIPTION
@smladeoye  headline1 is deprecated and not supported any more in the latest Flutter version.